### PR TITLE
Fixed error raised by column 'type' in table ong.

### DIFF
--- a/app/models/ong.rb
+++ b/app/models/ong.rb
@@ -5,6 +5,8 @@ class Ong < ActiveRecord::Base
   has_many :users, through: :ong_admins, foreign_key: :admins_user_id
   has_one :ong_detail
 
+  self.inheritance_column = :_type_disabled
+
   def user_is_admin?(user)
     user.ongs.include?(self)
   end


### PR DESCRIPTION
This error was raised because Ruby on Rails use a column named _type_ to refer to inheritance.
